### PR TITLE
fix: fixed omit-dependencies config on npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Ensures devDependencies are installed (overrides environment omit=dev setting)
+# Note: npm warns about empty value but it works correctly
+omit=


### PR DESCRIPTION
This PR implements a fix on npm config, the previous implementation became unable to be installed or built due to something in the Local environment breaking the omit dev dependencies = false flag on the npm config at the project scope level. The solution is to add a npmrc with omit= to make it not omit dev dependencies